### PR TITLE
Update FUNDING.yml to use named platform fields

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
 github: CatChen
 patreon: catchen
-custom: ["https://www.buymeacoffee.com/catchen"]
+buy_me_a_coffee: catchen
+ko_fi: catchen


### PR DESCRIPTION
## Summary

- Replace `custom: ['https://www.buymeacoffee.com/catchen']` with the native `buy_me_a_coffee: catchen` field
- Add `ko_fi: catchen` support
- Aligns with the standard FUNDING.yml format used across all CatChen repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)